### PR TITLE
Add "Securing your Adafruit IO Account" to cookbook pages

### DIFF
--- a/source/cookbook.html.erb
+++ b/source/cookbook.html.erb
@@ -29,6 +29,7 @@ includes:
   - cookbook/images.md.erb
   - cookbook/sending_json.md.erb
   - cookbook/webhook_receivers.md.erb
+  - cookbook/securing_io_account.md.erb
 
 search: true
 ---

--- a/source/includes/cookbook/_securing_io_account.md.erb
+++ b/source/includes/cookbook/_securing_io_account.md.erb
@@ -1,0 +1,17 @@
+# Securing your IO Account
+
+Your IO Account includes a secret API key. This key is private and should not be shared with anyone.
+
+But, a common pitfalls of the key is it may be accidentally shared by posted code on GitHub or social media. If anyone gains access to your key, **they will have access to your Adafruit IO account**.
+
+## I accidentially shared my key, what do I do now?
+
+You'll need to generate a new key. This process is simple, but not reversable. Once you generate a new key for your Adafruit IO account,
+all devices using the previous Adafruit IO key will need to be updated to the new key.
+
+
+To rengenerate your Adafruit IO Key:
+* Navigate to io.adafruit.com and log into your account.
+* Click the key icon on the header.
+* Click the "Regenerate Key" button and confirm the action.
+* The value of "Active Key" will change to a new key. Replace all instances of the previous key with the new one.


### PR DESCRIPTION
Resolves https://github.com/adafruit/Adafruit_IO_Documentation/issues/44 by moving the contents of the "Securing your Adafruit IO Account" page from Learn to our API documentation. The best place for this currently is the cookbook section of the docs.