### PR TITLE
Datums - Update parameter tables for datum endpoints

### DIFF
--- a/source/includes/cookbook/_sending_json.md.erb
+++ b/source/includes/cookbook/_sending_json.md.erb
@@ -88,4 +88,4 @@ atob("eyJzb21ldGhpbmciOiJoZXJlIn0=")
 ```
 <% end %>
 
-This solution is also ideal if you want to store or send binary data with Adafruit IO. You won't get to see any pretty charts, but your data will remain exactly the way you left it.
+This solution is also ideal if you want to store or send binary data with Adafruit IO. You won't get to see any pretty charts (although we do display base64 encoded images), but your data will remain exactly the way you left it.

--- a/source/includes/http/_data.md.erb
+++ b/source/includes/http/_data.md.erb
@@ -6,7 +6,7 @@ You can create, read, update, or delete data records. Every **CREATE**, **UPDATE
 
 Data points belong to feeds, so every Data API call starts with a Feed URL.
 
-
+Note that there are endpoints for submitting multiple data points to a feed, and multiple feed values to a group, see **feeds/{feed_key}/batch** and **groups/{groupname}/data** endpoints.
 
 ## Create Data
 
@@ -76,7 +76,7 @@ feed_key | string | true | a valid feed key
 
 Parameter |   Type  |  Required |       Description
 --------- | ------- | --------- | -----------------------
-datum | object | true | Data record including a `value` field (required) and optionally including: `lat`, `lon`, `ele` (latitude, longitude, and elevation values), and `created_at` (a date/time string).
+<b>Request Body</b> | object | true | Data record (datum) including a `value` field (required) and optionally including: `lat`, `lon`, `ele` (latitude, longitude, and elevation values), and `created_at` (a date/time string).
 
 
 
@@ -562,7 +562,7 @@ id | string | true |
 
 Parameter |   Type  |  Required |       Description
 --------- | ------- | --------- | -----------------------
-datum | object | true | Data record including a `value` field (required) and optionally including: `lat`, `lon`, `ele` (latitude, longitude, and elevation values), and `created_at` (a date/time string).
+<b>Request Body</b> | object | true | Data record (datum) including a `value` field (required) and optionally including: `lat`, `lon`, `ele` (latitude, longitude, and elevation values), and `created_at` (a date/time string).
 
 
 
@@ -724,7 +724,7 @@ feed_key | string | true | a valid feed key
 
 Parameter |   Type  |  Required |       Description
 --------- | ------- | --------- | -----------------------
-datum | object | true | Data record including a `value` field (required) and optionally including: `lat`, `lon`, `ele` (latitude, longitude, and elevation values), and `created_at` (a date/time string).
+<b>Request Body</b> | object | true | Data record (datum) including a `value` field (required) and optionally including: `lat`, `lon`, `ele` (latitude, longitude, and elevation values), and `created_at` (a date/time string).
 
 
 

--- a/source/includes/http/_feeds.md.erb
+++ b/source/includes/http/_feeds.md.erb
@@ -6,6 +6,8 @@ You will need to create one feed for each unique source of data you send to Adaf
 
 You can create, read, update, or delete feeds. Every **CREATE**, **UPDATE**, or **DELETE** action on a feed record counts against your rate limit.
 
+There are also endpoints for submitting multiple data points to a feed, or multiple feed values to a group, see **feeds/{feed_key}/batch** and **groups/{groupname}/data** endpoints.
+
 ## All Feeds
 
 > HTTP Request

--- a/source/includes/http/_groups.md.erb
+++ b/source/includes/http/_groups.md.erb
@@ -53,6 +53,7 @@ For example, if you are building a weather station, you would add feeds for `hum
 
 You can create, read, update, or delete group records. Every **CREATE**, **UPDATE**, or **DELETE** action on a group record counts against your rate limit.
 
+There is also an endpoint for submitting multiple feed values to a group, see the **groups/{groupname}/data** endpoint.
 
 ## Get All Groups
 


### PR DESCRIPTION
Adds instructions about submitting multiple data points in one operation.
Swaps the parameter name from datum to "Request Body" for single data endpoints.
Fixes #58